### PR TITLE
Feat/#4 북마크 목록 조회

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### DS_Store ###
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,14 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/matzipbookserver/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/example/matzipbookserver/bookmark/controller/BookmarkController.java
@@ -1,0 +1,27 @@
+package com.example.matzipbookserver.bookmark.controller;
+
+import com.example.matzipbookserver.bookmark.controller.dto.response.BookmarkInfo;
+import com.example.matzipbookserver.bookmark.controller.dto.response.BookmarkResponse;
+import com.example.matzipbookserver.bookmark.service.BookmarkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/bookmarks")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<BookmarkResponse> getUserBookmarks(@PathVariable Long userId) {
+        List<BookmarkInfo> bookmarks = bookmarkService.getBookmarksByUserId(userId);
+        return ResponseEntity.ok(new BookmarkResponse(bookmarks));
+    }
+}

--- a/src/main/java/com/example/matzipbookserver/bookmark/controller/dto/response/BookmarkInfo.java
+++ b/src/main/java/com/example/matzipbookserver/bookmark/controller/dto/response/BookmarkInfo.java
@@ -1,0 +1,5 @@
+package com.example.matzipbookserver.bookmark.controller.dto.response;
+
+public record BookmarkInfo(
+        Long storeId
+) {}

--- a/src/main/java/com/example/matzipbookserver/bookmark/controller/dto/response/BookmarkResponse.java
+++ b/src/main/java/com/example/matzipbookserver/bookmark/controller/dto/response/BookmarkResponse.java
@@ -1,0 +1,7 @@
+package com.example.matzipbookserver.bookmark.controller.dto.response;
+
+import java.util.List;
+
+public record BookmarkResponse(
+        List<BookmarkInfo> bookmarks
+) {}

--- a/src/main/java/com/example/matzipbookserver/bookmark/domain/entity/BookmarkEntity.java
+++ b/src/main/java/com/example/matzipbookserver/bookmark/domain/entity/BookmarkEntity.java
@@ -1,0 +1,25 @@
+package com.example.matzipbookserver.bookmark.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name="bookmark")
+public class BookmarkEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long userId;
+    private Long storeId;
+
+    @Builder
+    public BookmarkEntity(Long userId, Long storeId) {
+        this.userId = userId;
+        this.storeId = storeId;
+    }
+}

--- a/src/main/java/com/example/matzipbookserver/bookmark/domain/repository/BookmarkRepository.java
+++ b/src/main/java/com/example/matzipbookserver/bookmark/domain/repository/BookmarkRepository.java
@@ -1,0 +1,9 @@
+package com.example.matzipbookserver.bookmark.domain.repository;
+
+import com.example.matzipbookserver.bookmark.domain.entity.BookmarkEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> {
+    List<BookmarkEntity> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/matzipbookserver/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/example/matzipbookserver/bookmark/service/BookmarkService.java
@@ -1,0 +1,25 @@
+package com.example.matzipbookserver.bookmark.service;
+
+import com.example.matzipbookserver.bookmark.controller.dto.request.BookmarkRequest;
+import com.example.matzipbookserver.bookmark.controller.dto.response.BookmarkInfo;
+import com.example.matzipbookserver.bookmark.domain.repository.BookmarkRepository;
+import com.example.matzipbookserver.bookmark.domain.entity.BookmarkEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+
+    public List<BookmarkInfo> getBookmarksByUserId(Long userId) {
+        List<BookmarkEntity> bookmarks = bookmarkRepository.findByUserId(userId);
+        return bookmarks.stream()
+                .map(bookmark -> new BookmarkInfo(bookmark.getStoreId()))
+                .toList();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Resolved #4 

## 📝 작업 내용
북마크 관련 기능 중 북마크 목록 조회 기능을 구현했습니다.
가게 및 유저 도메인이 아직 추가되지 않아서 임시 데이터 기반으로 구조를 설계했습니다.

### 1️⃣ 북마크 목록 조회 기능 구현
- `GET /api/bookmarks/{userId}` 경로를 통해 특정 유저의 북마크된 storeId 목록을 조회합니다.
- 응답은 `BookmarkInfo(storeId)` 리스트를 `BookmarkResponse(bookmarks: List<BookmarkInfo>)` 형태로 감쌌습니다.
- 일단 지금은  storeId만 응답하는데, 추후 가게 도메인이 연결되면 가게 이름, 썸네일 사진 등을 포함할 예정입니다.
    ```java
    public record BookmarkInfo(
        Long storeId
    ) {}
    ```
### 2️⃣ 연관 도메인 부재 이슈
**연관관계**
- 가게 및 유저 도메인이 아직 존재하지 않아서 일단 간단하게 userId, storeId로 처리했습니다.
- 이후 도메인 추가 시 연관관계 매핑으로 리팩토링할 예정입니다.

**테스트**
- 관련 도메인이 없다 보니 RestDocs 테스트 시 목데이터를 세팅하는 데에 어려움이 있기 때문에 리팩토링 후 RestDocs 테스트를 진행해서 문서화할 예정입니다.
- 대신 @ Mock 기반의 순수 유닛 테스트를 작성하여 서비스 로직에 대한 검증은 완료했습니다.

## 💬 리뷰 요구사항 (선택)
이상한 부분 있으면 코멘트 달아주세요...
어 지금 보니 엔티티 추가 커밋에 build.gradle이 같이 들어갔네요 죄송합니다... jpa랑 lombok 넣었어요