### PR TITLE
Feat/#6 카카오/애플 소셜 로그인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/application-local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,18 @@ ext {
 }
 
 dependencies {
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.31'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/matzipbookserver/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/matzipbookserver/global/config/RestTemplateConfig.java
@@ -1,0 +1,23 @@
+package com.example.matzipbookserver.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setMessageConverters(List.of(
+                new FormHttpMessageConverter(),
+                new MappingJackson2HttpMessageConverter()
+        ));
+        return restTemplate;
+    }
+}
+

--- a/src/main/java/com/example/matzipbookserver/global/response/error/AuthErrorCode.java
+++ b/src/main/java/com/example/matzipbookserver/global/response/error/AuthErrorCode.java
@@ -1,0 +1,39 @@
+package com.example.matzipbookserver.global.response.error;
+
+import org.springframework.http.HttpStatus;
+
+public enum AuthErrorCode implements ErrorCode {
+    KAKAO_TOKEN_REQUEST_FAIL("AUTH-001", HttpStatus.BAD_REQUEST, "카카오 토큰 요청에 실패했습니다." ),
+    KAKAO_USER_INFO_FAIL("AUTH-002",HttpStatus.BAD_REQUEST, "카카오 사용자 정보 요청에 실패했습니다."),
+    KAKAO_EMAIL_NOT_PROVIDED("AUTH-003", HttpStatus.BAD_REQUEST, "이메일 정보가 제공되지 않았습니다."),
+    APPLE_TOKEN_REQUEST_FAIL("AUTH-004", HttpStatus.BAD_REQUEST, "애플 토큰 요청에 실패했습니다."),
+    APPLE_EMAIL_NOT_PROVIDED("AUTH-005", HttpStatus.BAD_REQUEST, "애플 이메일 정보가 제공되지 않았습니다."),
+    APPLE_ID_TOKEN_PARSE_FAILED("AUTH-006", HttpStatus.UNAUTHORIZED, "Apple ID Token 파싱에 실패했습니다.");
+
+    private final String developCode;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    AuthErrorCode(String developCode, HttpStatus httpStatus, String message) {
+        this.developCode = developCode;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String getDevelopCode() {
+        return developCode;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}
+
+

--- a/src/main/java/com/example/matzipbookserver/global/response/success/MemberSuccessCode.java
+++ b/src/main/java/com/example/matzipbookserver/global/response/success/MemberSuccessCode.java
@@ -1,0 +1,34 @@
+package com.example.matzipbookserver.global.response.success;
+
+import org.springframework.http.HttpStatus;
+
+public enum MemberSuccessCode implements SuccessCode {
+    LOGIN_SUCCESS(HttpStatus.OK,"MEMBER-001","로그인 성공"),
+    SIGNUP_REQUIRED(HttpStatus.OK, "MEMBER-002", "회원가입 필요");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    MemberSuccessCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/com/example/matzipbookserver/member/controller/AuthController.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/AuthController.java
@@ -1,0 +1,62 @@
+package com.example.matzipbookserver.member.controller;
+
+
+import com.example.matzipbookserver.global.response.SuccessResponse;
+import com.example.matzipbookserver.global.response.success.MemberSuccessCode;
+import com.example.matzipbookserver.member.controller.dto.request.AppleLoginRequest;
+import com.example.matzipbookserver.member.controller.dto.request.KakaoLoginRequest;
+import com.example.matzipbookserver.member.controller.dto.response.AppleLoginResponse;
+import com.example.matzipbookserver.member.controller.dto.response.KakaoLoginResponse;
+import com.example.matzipbookserver.member.controller.dto.response.LoginResponse;
+import com.example.matzipbookserver.member.service.AuthService;
+import com.example.matzipbookserver.member.service.FcmTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    private final FcmTokenService fcmTokenService;
+
+
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<?> kakaoCallback(@RequestParam String code) {
+        return ResponseEntity.ok("카카오 인가코드 수신 완료: " + code);
+    }
+
+    @PostMapping("/login/kakao")
+    public ResponseEntity<?> kakaoLogin(@RequestBody KakaoLoginRequest request) {
+        LoginResponse response = authService.kakaoLogin(request.code(), request.fcmToken());
+
+        if(response instanceof KakaoLoginResponse) {
+            return SuccessResponse.of(MemberSuccessCode.LOGIN_SUCCESS,response);
+        } else {
+            return SuccessResponse.of(MemberSuccessCode.SIGNUP_REQUIRED,response);
+        }
+    }
+
+
+    @PostMapping("/apple/callback")
+    public ResponseEntity<?> appleCallback(@RequestParam String code,
+                                           @RequestParam(required = false) String id_token) {
+        return ResponseEntity.ok("애플 인가코드 수신 완료: " + code);
+    }
+
+    @PostMapping("/login/apple")
+    public ResponseEntity<?> appleLogin(@RequestBody AppleLoginRequest request) {
+
+        LoginResponse response = authService.appleLogin(request.code(), request.fcmToken());
+
+        if(response instanceof AppleLoginResponse) {
+            return SuccessResponse.of(MemberSuccessCode.LOGIN_SUCCESS,response);
+        } else {
+            return SuccessResponse.of(MemberSuccessCode.SIGNUP_REQUIRED,response);
+        }
+    }
+
+
+}

--- a/src/main/java/com/example/matzipbookserver/member/controller/dto/request/AppleLoginRequest.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/dto/request/AppleLoginRequest.java
@@ -1,0 +1,3 @@
+package com.example.matzipbookserver.member.controller.dto.request;
+
+public record AppleLoginRequest (String code, String fcmToken) {}

--- a/src/main/java/com/example/matzipbookserver/member/controller/dto/request/FcmTokenRequest.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/dto/request/FcmTokenRequest.java
@@ -1,0 +1,3 @@
+package com.example.matzipbookserver.member.controller.dto.request;
+
+public record FcmTokenRequest (String fcmToken) {}

--- a/src/main/java/com/example/matzipbookserver/member/controller/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,6 @@
+package com.example.matzipbookserver.member.controller.dto.request;
+
+public record KakaoLoginRequest(
+        String code,
+        String fcmToken
+) {}

--- a/src/main/java/com/example/matzipbookserver/member/controller/dto/response/AppleLoginResponse.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/dto/response/AppleLoginResponse.java
@@ -1,0 +1,5 @@
+package com.example.matzipbookserver.member.controller.dto.response;
+
+public record AppleLoginResponse (String jwtToken, UserInfo user) implements LoginResponse {
+    public record UserInfo(Long id, String email) {}
+}

--- a/src/main/java/com/example/matzipbookserver/member/controller/dto/response/KakaoLoginResponse.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/dto/response/KakaoLoginResponse.java
@@ -1,0 +1,12 @@
+package com.example.matzipbookserver.member.controller.dto.response;
+
+
+public record KakaoLoginResponse (
+    String jwtToken,
+    UserInfo user
+) implements LoginResponse{
+    public record UserInfo(
+            Long id,
+            String email
+    ) {}
+}

--- a/src/main/java/com/example/matzipbookserver/member/controller/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/dto/response/LoginResponse.java
@@ -1,0 +1,4 @@
+package com.example.matzipbookserver.member.controller.dto.response;
+
+public interface LoginResponse {
+}

--- a/src/main/java/com/example/matzipbookserver/member/controller/dto/response/SignupNeededResponse.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/dto/response/SignupNeededResponse.java
@@ -1,0 +1,6 @@
+package com.example.matzipbookserver.member.controller.dto.response;
+
+public record SignupNeededResponse(
+        String email,
+        String providerId
+) implements LoginResponse {}

--- a/src/main/java/com/example/matzipbookserver/member/domain/FcmToken.java
+++ b/src/main/java/com/example/matzipbookserver/member/domain/FcmToken.java
@@ -1,0 +1,29 @@
+package com.example.matzipbookserver.member.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+public class FcmToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String fcmToken;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    public FcmToken( Member member, String fcmToken) {
+        this.fcmToken = fcmToken;
+        this.member = member;
+    }
+
+    public void update(String newFcmToken) {
+        this.fcmToken = newFcmToken;
+    }
+
+    protected FcmToken() {} //JPA 기본 생성자
+}
+
+

--- a/src/main/java/com/example/matzipbookserver/member/domain/Member.java
+++ b/src/main/java/com/example/matzipbookserver/member/domain/Member.java
@@ -1,0 +1,21 @@
+package com.example.matzipbookserver.member.domain;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String provider;
+    private String providerId;
+    private String email;
+}

--- a/src/main/java/com/example/matzipbookserver/member/repository/FcmTokenRepository.java
+++ b/src/main/java/com/example/matzipbookserver/member/repository/FcmTokenRepository.java
@@ -1,0 +1,11 @@
+package com.example.matzipbookserver.member.repository;
+
+import com.example.matzipbookserver.member.domain.FcmToken;
+import com.example.matzipbookserver.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+    Optional<FcmToken> findByMember(Member member);
+}

--- a/src/main/java/com/example/matzipbookserver/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/matzipbookserver/member/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.example.matzipbookserver.member.repository;
+
+import com.example.matzipbookserver.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByProviderAndProviderId(String provider, String providerId);
+
+}

--- a/src/main/java/com/example/matzipbookserver/member/service/AuthService.java
+++ b/src/main/java/com/example/matzipbookserver/member/service/AuthService.java
@@ -1,0 +1,107 @@
+package com.example.matzipbookserver.member.service;
+
+import com.example.matzipbookserver.global.exception.RestApiException;
+import com.example.matzipbookserver.global.response.error.AuthErrorCode;
+import com.example.matzipbookserver.member.controller.dto.response.KakaoLoginResponse;
+import com.example.matzipbookserver.member.controller.dto.response.AppleLoginResponse;
+import com.example.matzipbookserver.member.controller.dto.response.LoginResponse;
+import com.example.matzipbookserver.member.controller.dto.response.SignupNeededResponse;
+import com.example.matzipbookserver.member.domain.Member;
+import com.example.matzipbookserver.member.repository.MemberRepository;
+import com.example.matzipbookserver.member.util.AppleOAuthUtil;
+import com.example.matzipbookserver.member.util.dto.AppleIdTokenPayload;
+import com.example.matzipbookserver.member.util.dto.AppleTokenResponse;
+import com.example.matzipbookserver.member.util.dto.KakaoTokenDTO;
+import com.example.matzipbookserver.member.util.dto.KakaoUserDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import com.example.matzipbookserver.member.util.KakaoOAuthUtil;
+
+import java.util.Optional;
+
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoOAuthUtil kakaoOAuthUtil;
+    private final MemberRepository memberRepository;
+    private final FcmTokenService fcmTokenService;
+    private final AppleOAuthUtil appleOAuthUtil;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public LoginResponse kakaoLogin(String code, String fcmToken) {
+
+
+        KakaoTokenDTO tokenDto;
+        try {
+            tokenDto = kakaoOAuthUtil.requestToken(code);
+        } catch (Exception e) {
+            throw new RestApiException(AuthErrorCode.KAKAO_TOKEN_REQUEST_FAIL);
+        }
+
+        KakaoUserDTO userInfo;
+        try {
+            userInfo = kakaoOAuthUtil.requestUserInfo(tokenDto.accessToken());
+        } catch (Exception e) {
+            throw new RestApiException(AuthErrorCode.KAKAO_USER_INFO_FAIL);
+        }
+        if (userInfo.kakaoAccount() == null || userInfo.kakaoAccount().email() == null) {
+            throw new RestApiException(AuthErrorCode.KAKAO_EMAIL_NOT_PROVIDED);
+        }
+
+        String email = userInfo.kakaoAccount().email();
+        String providerId = String.valueOf(userInfo.id());
+
+
+
+        Optional<Member> member = memberRepository.findByProviderAndProviderId("kakao",providerId);
+
+        if(member.isPresent()){
+            fcmTokenService.saveOrUpdate(member.get(), fcmToken);
+            String jwt = jwtTokenProvider.createAccessToken(member.get().getEmail());
+            return new KakaoLoginResponse(jwt, new KakaoLoginResponse.UserInfo(member.get().getId(), member.get().getEmail()));
+        } else {
+            return new SignupNeededResponse(email, providerId);
+        }
+
+    }
+
+    public LoginResponse appleLogin(String code, String fcmToken) {
+
+        AppleTokenResponse tokenResponse;
+
+        try {
+            tokenResponse = appleOAuthUtil.requestToken(code);
+        } catch (Exception e) {
+            throw new RestApiException(AuthErrorCode.APPLE_TOKEN_REQUEST_FAIL);
+        }
+
+        AppleIdTokenPayload userInfo;
+
+        try {
+            userInfo = appleOAuthUtil.parseIdToken(tokenResponse.id_token());
+        } catch (Exception e) {
+            throw new RestApiException(AuthErrorCode.APPLE_ID_TOKEN_PARSE_FAILED);
+        }
+
+        if (userInfo.email() == null) {
+            throw new RestApiException(AuthErrorCode.APPLE_EMAIL_NOT_PROVIDED);
+        }
+
+
+        String email = userInfo.email();
+        String providerId = userInfo.sub();
+
+        Optional<Member> member = memberRepository.findByProviderAndProviderId("apple",providerId);
+
+        if (member.isPresent()) {
+            fcmTokenService.saveOrUpdate(member.get(), fcmToken);
+            String jwt = jwtTokenProvider.createAccessToken(member.get().getEmail());
+            return new AppleLoginResponse(jwt, new AppleLoginResponse.UserInfo(member.get().getId(), member.get().getEmail()));
+        } else {
+            return new SignupNeededResponse(email, providerId);
+        }
+    }
+
+}

--- a/src/main/java/com/example/matzipbookserver/member/service/FcmTokenService.java
+++ b/src/main/java/com/example/matzipbookserver/member/service/FcmTokenService.java
@@ -1,0 +1,28 @@
+package com.example.matzipbookserver.member.service;
+
+import com.example.matzipbookserver.member.domain.FcmToken;
+import com.example.matzipbookserver.member.domain.Member;
+import com.example.matzipbookserver.member.repository.FcmTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FcmTokenService {
+    private final FcmTokenRepository fcmTokenRepository;
+
+    public void saveOrUpdate(Member member,String fcmToken) {
+
+        //해당 유저의 fcmToken이 존재하면 갱신, 없으면 새로 저장
+        fcmTokenRepository.findByMember(member)
+                .ifPresentOrElse(
+                        existing -> {
+                            existing.update(fcmToken);
+                            fcmTokenRepository.save(existing);
+                        },
+                        () -> {
+                            fcmTokenRepository.save(new FcmToken(member, fcmToken));
+                        });
+
+    }
+}

--- a/src/main/java/com/example/matzipbookserver/member/service/JwtTokenProvider.java
+++ b/src/main/java/com/example/matzipbookserver/member/service/JwtTokenProvider.java
@@ -1,0 +1,33 @@
+package com.example.matzipbookserver.member.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        byte[] decodedKey = Base64.getDecoder().decode(secret);
+        this.secretKey = Keys.hmacShaKeyFor(decodedKey);
+    }
+    public String createAccessToken(String email) {
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 3600 * 1000))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/example/matzipbookserver/member/util/AppleOAuthUtil.java
+++ b/src/main/java/com/example/matzipbookserver/member/util/AppleOAuthUtil.java
@@ -39,8 +39,8 @@ public class AppleOAuthUtil {
     @Value("${apple.key-id}")
     private String keyId;
 
-    @Value("${apple.key-path}")
-    private Resource keyFile;
+    @Value("${apple.private-key}")
+    private String privateKeyPem;
 
     @Value("${apple.redirect-uri}")
     private String redirectUri;
@@ -98,7 +98,7 @@ public class AppleOAuthUtil {
 
     private PrivateKey getPrivateKey() {
         try {
-            String keyContent = new String(keyFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8)
+            String keyContent = privateKeyPem
                     .replace("-----BEGIN PRIVATE KEY-----", "")
                     .replace("-----END PRIVATE KEY-----", "")
                     .replaceAll("\\s", "");

--- a/src/main/java/com/example/matzipbookserver/member/util/AppleOAuthUtil.java
+++ b/src/main/java/com/example/matzipbookserver/member/util/AppleOAuthUtil.java
@@ -1,0 +1,116 @@
+package com.example.matzipbookserver.member.util;
+
+import com.example.matzipbookserver.member.util.dto.AppleIdTokenPayload;
+import com.example.matzipbookserver.member.util.dto.AppleTokenResponse;
+import org.springframework.core.io.Resource;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class AppleOAuthUtil {
+
+    private final RestTemplate restTemplate;
+    @Value("${apple.team-id}")
+    private String teamId;
+
+    @Value("${apple.client-id}")
+    private String clientId;
+
+    @Value("${apple.key-id}")
+    private String keyId;
+
+    @Value("${apple.key-path}")
+    private Resource keyFile;
+
+    @Value("${apple.redirect-uri}")
+    private String redirectUri;
+
+    private final static String APPLE_AUTH_URL = "https://appleid.apple.com";
+
+    public AppleTokenResponse requestToken(String code) {
+        String clientSecret = createClientSecret();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("grant_type", "authorization_code");
+        body.add("code", code);
+        body.add("redirect_uri", redirectUri);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<AppleTokenResponse> response = restTemplate.exchange(
+                APPLE_AUTH_URL + "/auth/token",
+                HttpMethod.POST,
+                request,
+                AppleTokenResponse.class
+        );
+        return response.getBody();
+    }
+
+    public AppleIdTokenPayload parseIdToken(String idToken) throws ParseException, java.text.ParseException, IOException {
+        SignedJWT signedJWT = SignedJWT.parse(idToken);
+        JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+
+        return new AppleIdTokenPayload (
+                claims.getSubject(),
+                claims.getStringClaim("email")
+        );
+    }
+
+    private String createClientSecret() {
+        Instant now = Instant.now();
+        Instant exp = now.plusSeconds(180); // 3분짜리 client_secret
+
+        return Jwts.builder()
+                .setHeaderParam("alg","ES256")
+                .setHeaderParam("kid",keyId)
+                .setIssuer(teamId)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(exp))
+                .setAudience("https://appleid.apple.com")
+                .setSubject(clientId)
+                .signWith(SignatureAlgorithm.ES256, getPrivateKey())
+                .compact();
+    }
+
+    private PrivateKey getPrivateKey() {
+        try {
+            String keyContent = new String(keyFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8)
+                    .replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replace("-----END PRIVATE KEY-----", "")
+                    .replaceAll("\\s", "");
+
+            byte[] pkcs8EncodedBytes = Base64.getDecoder().decode(keyContent);
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(pkcs8EncodedBytes);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return keyFactory.generatePrivate(keySpec);
+        } catch (Exception e) {
+            throw new RuntimeException("애플 private key 로드에 실패했습니다.",e);
+        }
+    }
+
+
+}

--- a/src/main/java/com/example/matzipbookserver/member/util/KakaoOAuthUtil.java
+++ b/src/main/java/com/example/matzipbookserver/member/util/KakaoOAuthUtil.java
@@ -1,0 +1,63 @@
+package com.example.matzipbookserver.member.util;
+
+import com.example.matzipbookserver.member.util.dto.KakaoTokenDTO;
+import com.example.matzipbookserver.member.util.dto.KakaoUserDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthUtil {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    public KakaoTokenDTO requestToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<KakaoTokenDTO> response = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                request,
+                KakaoTokenDTO.class
+        );
+
+        return response.getBody();
+    }
+
+    public KakaoUserDTO requestUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<KakaoUserDTO> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                request,
+                KakaoUserDTO.class
+        );
+
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/example/matzipbookserver/member/util/dto/AppleIdTokenPayload.java
+++ b/src/main/java/com/example/matzipbookserver/member/util/dto/AppleIdTokenPayload.java
@@ -1,0 +1,6 @@
+package com.example.matzipbookserver.member.util.dto;
+
+public record AppleIdTokenPayload (
+    String sub, // 애플 식별자
+    String email // 유저 이메일
+) {}

--- a/src/main/java/com/example/matzipbookserver/member/util/dto/AppleTokenResponse.java
+++ b/src/main/java/com/example/matzipbookserver/member/util/dto/AppleTokenResponse.java
@@ -1,0 +1,9 @@
+package com.example.matzipbookserver.member.util.dto;
+
+public record AppleTokenResponse (
+        String access_token,
+        String id_token,
+        String refresh_token,
+        String token_type,
+        Long expires_in
+) {}

--- a/src/main/java/com/example/matzipbookserver/member/util/dto/KakaoTokenDTO.java
+++ b/src/main/java/com/example/matzipbookserver/member/util/dto/KakaoTokenDTO.java
@@ -1,0 +1,23 @@
+package com.example.matzipbookserver.member.util.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenDTO (
+    @JsonProperty("access_token")
+    String accessToken,
+
+    @JsonProperty("token_type")
+    String tokenType,
+
+    @JsonProperty("refresh_token")
+    String refreshToken,
+
+    @JsonProperty("expires_in")
+    int expiresIn,
+
+    @JsonProperty("scope")
+    String scope,
+
+    @JsonProperty("refresh_token_expires_in")
+    int refreshTokenExpiresIn
+) {}

--- a/src/main/java/com/example/matzipbookserver/member/util/dto/KakaoUserDTO.java
+++ b/src/main/java/com/example/matzipbookserver/member/util/dto/KakaoUserDTO.java
@@ -1,0 +1,16 @@
+package com.example.matzipbookserver.member.util.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserDTO (
+        Long id,
+        @JsonProperty("connected_at")
+        String connectedAt,
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount (
+            String email
+    ) {}
+
+}

--- a/src/test/java/com/example/matzipbookserver/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/matzipbookserver/member/controller/AuthControllerTest.java
@@ -1,0 +1,190 @@
+package com.example.matzipbookserver.member.controller;
+
+import com.example.matzipbookserver.global.exception.ApiExceptionHandler;
+import com.example.matzipbookserver.global.exception.RestApiException;
+import com.example.matzipbookserver.global.response.error.AuthErrorCode;
+import com.example.matzipbookserver.member.controller.dto.request.AppleLoginRequest;
+import com.example.matzipbookserver.member.controller.dto.request.KakaoLoginRequest;
+import com.example.matzipbookserver.member.controller.dto.response.AppleLoginResponse;
+import com.example.matzipbookserver.member.controller.dto.response.KakaoLoginResponse;
+import com.example.matzipbookserver.member.controller.dto.response.SignupNeededResponse;
+import com.example.matzipbookserver.member.service.AuthService;
+import com.example.matzipbookserver.member.service.FcmTokenService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(RestDocumentationExtension.class)
+@WebMvcTest(AuthController.class)
+@Import(AuthControllerTest.AuthControllerTestConfig.class)
+public class AuthControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private RestDocumentationResultHandler restDocs;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockMvc mockMvc;
+
+    private AuthService authService = Mockito.mock(AuthService.class);
+    private FcmTokenService fcmTokenService = Mockito.mock(FcmTokenService.class);
+
+    @BeforeEach
+    void setup(RestDocumentationContextProvider restDocumentation) {
+
+        this.restDocs = document("{class-name}/{method-name}");
+        this.mockMvc = MockMvcBuilders
+                .standaloneSetup(new AuthController(authService, fcmTokenService))
+                .setControllerAdvice(new ApiExceptionHandler())
+                .apply(documentationConfiguration(restDocumentation))
+                .alwaysDo(print())
+                .alwaysDo(restDocs)
+                .build();
+    }
+
+    @TestConfiguration
+    static class AuthControllerTestConfig {
+        @Bean
+        public AuthService authService() {
+            return Mockito.mock(AuthService.class);
+        }
+
+        @Bean
+        public FcmTokenService fcmTokenService() {
+            return Mockito.mock(FcmTokenService.class);
+        }
+    }
+
+    @Test
+    void 카카오_로그인_성공_테스트() throws Exception {
+        // given
+        KakaoLoginRequest request = new KakaoLoginRequest("code111", "fcmToken111");
+        KakaoLoginResponse response = new KakaoLoginResponse("fake-jwt-token", new KakaoLoginResponse.UserInfo(1L,"test@email.com"));
+
+        Mockito.when(authService.kakaoLogin(anyString(), anyString())).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login/kakao")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("로그인 성공"))
+                .andExpect(jsonPath("$.result.jwtToken").value("fake-jwt-token"))
+                .andExpect(jsonPath("$.result.user.email").value("test@email.com"))
+                .andDo(document("kakao-login-success"));
+
+    }
+
+    @Test
+    void 카카오_로그인_회원가입필요_테스트() throws Exception {
+        // given
+        KakaoLoginRequest request = new KakaoLoginRequest("code111", "fcmToken111");
+        KakaoLoginResponse response = new KakaoLoginResponse("fake-jwt-token", new KakaoLoginResponse.UserInfo(1L,"test@email.com"));
+
+
+        Mockito.when(authService.kakaoLogin(anyString(), anyString()))
+                .thenReturn(new SignupNeededResponse("test@email.com", "kakao123"));
+
+
+        // when&then
+        mockMvc.perform(post("/api/auth/login/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("회원가입 필요"))
+                .andExpect(jsonPath("$.result.email").value("test@email.com"))
+                .andDo(document("kakao-login-need-signup"));
+    }
+
+
+
+    @Test
+    void 애플_로그인_성공_테스트() throws Exception {
+        // given
+        AppleLoginRequest request = new AppleLoginRequest("code111", "fcmToken111");
+        AppleLoginResponse response = new AppleLoginResponse("fake-jwt-token", new AppleLoginResponse.UserInfo(1L,"test@email.com"));
+
+        Mockito.when(authService.appleLogin(anyString(), anyString())).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login/apple")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("로그인 성공"))
+                .andExpect(jsonPath("$.result.jwtToken").value("fake-jwt-token"))
+                .andExpect(jsonPath("$.result.user.email").value("test@email.com"))
+                .andDo(document("apple-login-success"));
+    }
+
+    @Test
+    void 애플_로그인_회원가입필요_테스트() throws Exception {
+        // given
+        AppleLoginRequest request = new AppleLoginRequest("code111", "fcmToken111");
+        AppleLoginResponse response = new AppleLoginResponse("fake-jwt-token", new AppleLoginResponse.UserInfo(1L,"test@email.com"));
+
+
+        Mockito.when(authService.appleLogin(anyString(), anyString()))
+                .thenReturn(new SignupNeededResponse("test@email.com", "apple123"));
+
+
+
+        // when&then
+        mockMvc.perform(post("/api/auth/login/apple")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("회원가입 필요"))
+                .andExpect(jsonPath("$.result.email").value("test@email.com"))
+                .andDo(print())
+                .andDo(document("apple-login-need-signup"));
+    }
+
+
+
+    @Test
+    void 애플_로그인_토큰파싱_실패_테스트() throws Exception {
+        //given
+        AppleLoginRequest request = new AppleLoginRequest("code111", "fcmToken111");
+
+        Mockito.when(authService.appleLogin(anyString(), anyString()))
+                .thenThrow(new RestApiException(AuthErrorCode.APPLE_ID_TOKEN_PARSE_FAILED));
+
+        //when&then
+        mockMvc.perform(post("/api/auth/login/apple")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string(containsString("AUTH-006")))
+                .andDo(document("apple-login-token-parse-failed"))
+                .andDo(print());
+    }
+
+
+
+}


### PR DESCRIPTION

## #️⃣ 연관된 이슈
Resolved #6 

## 📝 작업 내용
카카오/애플 소셜 로그인 기능을 구현했습니다.
OAuth 인가코드로 access token 요청 및 유저 정보 조회 후, 기존 회원 여부에 따라 로그인 성공 또는 회원가입 안내 응답을 반환합니다. 

### **1️⃣ 로그인 흐름**
- `POST /api/auth/login/kakao`
- `POST /api/auth/login/apple`
→ 인가코드 수신 → access token 요청 → 유저 정보 요청
→ 회원 존재 시 JWT 발급, 존재하지 않으면 회원가입 안내 응답
- 소셜 로그인 응답에는 이메일만 포함되며, 닉네임/생일 등은 회원가입 시 별도로 입력받을 예정입니다.

### **2️⃣ JWT & FCM**

- JWT는 이메일 기반으로 액세스 토큰 생성
- fcmToken은 현재 로그인 시 전달만 받고 있으며, 실제 저장 로직은 회원가입 구현할 때 처리할 예정입니다.

### 3️⃣ Redirect URI 관련

- OAuth 리디렉션 확인용으로 /kakao/callback, /apple/callback 핸들러가 있으며, 실제 인증 처리는 login API를 통해 처리합니다.
- 현재 애플 리디렉션은 테스트를 위해 ngrok 주소를 사용했습니다.

### 4️⃣ 테스트 및 문서화

- RestDocs는 기본 예시 출력까지만 구현, 필드 설명은 이후 추가 작업 예정입니다.
- 컨트롤러/서비스 단위 테스트 포함

### 5️⃣ build.gradle 수정사항

- 로그인 기능, 문서화, JWT 발급을 위한 의존성 추가
    - `spring-boot-starter-data-jpa`, `lombok`, `restdocs`, `jjwt`, `nimbus-jose-jwt`

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/89c24cfd-a413-41d6-ab23-f6869141de0b)


## 💬 리뷰 요구사항 (선택)

🙇‍♀️ 커밋을 나누지 못하고, 한번에 PR로 올리게 되어 죄송합니다.. 다음부터는 작업 단위로 구분해 커밋하도록 하겠습니다!!

🙇‍♀️ 구현은 최선을 다해 진행했지만, 코드에 대한 이해가 부족한 부분들이 있습니다. 어색한 로직이 있다면 편하게 코멘트 부탁드립니다 :)

📌 민감한 정보가 포함된 `application-local.properties`, `AuthKey_*.p8` 등은 커밋에서 제외 했습니다!