### PR TITLE
Feat/#3 가게 상세 조회

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ build/
 bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
-
+resources/application.yml
 ### IntelliJ IDEA ###
 .idea
 *.iws

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.5'
+    id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
@@ -20,6 +20,7 @@ repositories {
 
 ext {
     set('snippetsDir', file("build/generated-snippets"))
+    set('springCloudVersion', "2023.0.3")
 }
 
 dependencies {
@@ -27,6 +28,23 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    //lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    //mysql
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    //Feign
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/matzipbookserver/MatzipbookServerApplication.java
+++ b/src/main/java/com/example/matzipbookserver/MatzipbookServerApplication.java
@@ -2,7 +2,9 @@ package com.example.matzipbookserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class MatzipbookServerApplication {
 

--- a/src/main/java/com/example/matzipbookserver/global/config/KakaoFeignConfig.java
+++ b/src/main/java/com/example/matzipbookserver/global/config/KakaoFeignConfig.java
@@ -1,0 +1,21 @@
+package com.example.matzipbookserver.global.config;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KakaoFeignConfig {
+
+    @Value("${kakao.rest-api-key}")
+    private String kakaoApiKey;
+
+    @Bean
+    public RequestInterceptor kakaoRequestInterceptor() {
+        return requestTemplate -> {
+            requestTemplate.header("Authorization", "KakaoAK " + kakaoApiKey);
+        };
+    }
+
+}

--- a/src/main/java/com/example/matzipbookserver/global/response/error/StoreErrorCode.java
+++ b/src/main/java/com/example/matzipbookserver/global/response/error/StoreErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.matzipbookserver.global.response.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum StoreErrorCode implements ErrorCode{
+
+    STORE_NOT_EXIST("PLACE_NOT_FOUND_001", HttpStatus.NOT_FOUND,"카카오에서 장소를 찾을 수 없음");
+
+    private final String developCode;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/matzipbookserver/global/response/success/StoreSuccessCode.java
+++ b/src/main/java/com/example/matzipbookserver/global/response/success/StoreSuccessCode.java
@@ -1,0 +1,18 @@
+package com.example.matzipbookserver.global.response.success;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum StoreSuccessCode implements SuccessCode {
+
+    OK("STORE_SEARCH_SUCCESS", HttpStatus.OK, "가게 상세 조회 성공");
+
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/matzipbookserver/store/controller/StoreController.java
+++ b/src/main/java/com/example/matzipbookserver/store/controller/StoreController.java
@@ -1,0 +1,27 @@
+package com.example.matzipbookserver.store.controller;
+
+import com.example.matzipbookserver.global.response.SuccessResponse;
+import com.example.matzipbookserver.global.response.success.StoreSuccessCode;
+import com.example.matzipbookserver.store.controller.dto.StoreResponseDto;
+import com.example.matzipbookserver.store.service.StoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/store")
+@RestController
+public class StoreController {
+
+    private final StoreService storeService;
+
+    @GetMapping("/{kakaoPlaceId}")
+    public ResponseEntity<SuccessResponse<StoreResponseDto>> getStoreDetail(
+            @PathVariable String kakaoPlaceId,
+            @RequestParam String storeName,
+            @RequestParam double x,
+            @RequestParam double y) {
+        return SuccessResponse.of(StoreSuccessCode.OK, storeService.getPlaceDetail(kakaoPlaceId, storeName, x, y));
+    }
+
+}

--- a/src/main/java/com/example/matzipbookserver/store/controller/dto/StoreResponseDto.java
+++ b/src/main/java/com/example/matzipbookserver/store/controller/dto/StoreResponseDto.java
@@ -1,0 +1,30 @@
+package com.example.matzipbookserver.store.controller.dto;
+
+import com.example.matzipbookserver.store.domain.Store;
+import lombok.Builder;
+
+@Builder
+public record StoreResponseDto(
+        String kakaoPlaceId,
+        String name,
+        String address,
+        String roadAddress,
+        String phone,
+        double x,
+        double y,
+        String kakaoPlaceUrl
+) {
+
+    public static StoreResponseDto from(Store store) {
+        return new StoreResponseDto(
+                store.getKakaoPlaceId(),
+                store.getName(),
+                store.getAddress(),
+                store.getRoadAddress(),
+                store.getPhone(),
+                store.getX(),
+                store.getY(),
+                store.getKakaoPlaceUrl()
+        );
+    }
+}

--- a/src/main/java/com/example/matzipbookserver/store/domain/Store.java
+++ b/src/main/java/com/example/matzipbookserver/store/domain/Store.java
@@ -1,0 +1,40 @@
+package com.example.matzipbookserver.store.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Entity
+public class Store {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String kakaoPlaceId;
+
+    private String categoryName;
+
+    private String address;
+
+    private String roadAddress;
+
+    private String name;
+
+    private String phone;
+
+    private String kakaoPlaceUrl;
+
+    private Double x; //경도
+    private Double y; //위도
+
+    private int voteCount = 0;
+
+}

--- a/src/main/java/com/example/matzipbookserver/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/example/matzipbookserver/store/domain/repository/StoreRepository.java
@@ -1,0 +1,11 @@
+package com.example.matzipbookserver.store.domain.repository;
+
+import com.example.matzipbookserver.store.domain.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+
+    Optional<Store> findByKakaoPlaceId(String kakaoPlaceId);
+}

--- a/src/main/java/com/example/matzipbookserver/store/external/KakaoLocalClient.java
+++ b/src/main/java/com/example/matzipbookserver/store/external/KakaoLocalClient.java
@@ -1,0 +1,24 @@
+package com.example.matzipbookserver.store.external;
+
+import com.example.matzipbookserver.global.config.KakaoFeignConfig;
+import com.example.matzipbookserver.store.external.dto.KakaoSearchResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+        name = "kakaoLocalClient",
+        url = "https://dapi.kakao.com",
+        configuration = KakaoFeignConfig.class
+)
+public interface KakaoLocalClient {
+
+    @GetMapping("/v2/local/search/keyword.json")
+    KakaoSearchResponse searchPlaceByKeywordAndPos(
+            @RequestParam("query") String query,
+            @RequestParam("x") Double x,
+            @RequestParam("y") Double y,
+            @RequestParam(value = "radius", required = false) int radius, // optional, default: 1000m
+            @RequestParam("category_group_code") String categoryGroupCode
+    );
+}

--- a/src/main/java/com/example/matzipbookserver/store/external/dto/KakaoDocument.java
+++ b/src/main/java/com/example/matzipbookserver/store/external/dto/KakaoDocument.java
@@ -1,0 +1,16 @@
+package com.example.matzipbookserver.store.external.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoDocument(
+        String id,
+        @JsonProperty("place_name") String placeName,
+        @JsonProperty("category_name") String categoryName,
+        String phone,
+        @JsonProperty("address_name") String addressName,
+        @JsonProperty("road_address_name") String roadAddressName,
+        String x,
+        String y,
+        @JsonProperty("place_url") String placeUrl
+) {
+}

--- a/src/main/java/com/example/matzipbookserver/store/external/dto/KakaoMeta.java
+++ b/src/main/java/com/example/matzipbookserver/store/external/dto/KakaoMeta.java
@@ -1,0 +1,10 @@
+package com.example.matzipbookserver.store.external.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoMeta(
+        @JsonProperty("total_count") int totalCount,
+        @JsonProperty("pageable_count") int pageableCount,
+        @JsonProperty("is_end") boolean isEnd
+) {
+}

--- a/src/main/java/com/example/matzipbookserver/store/external/dto/KakaoSearchResponse.java
+++ b/src/main/java/com/example/matzipbookserver/store/external/dto/KakaoSearchResponse.java
@@ -1,0 +1,9 @@
+package com.example.matzipbookserver.store.external.dto;
+
+import java.util.List;
+
+public record KakaoSearchResponse(
+        KakaoMeta meta,
+        List<KakaoDocument> documents
+) {
+}

--- a/src/main/java/com/example/matzipbookserver/store/service/StoreService.java
+++ b/src/main/java/com/example/matzipbookserver/store/service/StoreService.java
@@ -1,0 +1,49 @@
+package com.example.matzipbookserver.store.service;
+
+import com.example.matzipbookserver.global.exception.RestApiException;
+import com.example.matzipbookserver.global.response.error.StoreErrorCode;
+import com.example.matzipbookserver.store.controller.dto.StoreResponseDto;
+import com.example.matzipbookserver.store.domain.Store;
+import com.example.matzipbookserver.store.domain.repository.StoreRepository;
+import com.example.matzipbookserver.store.external.KakaoLocalClient;
+import com.example.matzipbookserver.store.external.dto.KakaoDocument;
+import com.example.matzipbookserver.store.external.dto.KakaoSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class StoreService {
+
+    private final KakaoLocalClient kakaoLocalClient;
+    private final StoreRepository storeRepository;
+
+    public StoreResponseDto getPlaceDetail(String kakaoPlaceId, String placeName, double x, double y) {
+        Optional<Store> storeOptional = storeRepository.findByKakaoPlaceId(kakaoPlaceId);
+        if(storeOptional.isPresent()) {
+            return StoreResponseDto.from(storeOptional.get());
+        }
+
+        KakaoSearchResponse searchRes = kakaoLocalClient.searchPlaceByKeywordAndPos(placeName, x, y, 1000, "FD6"); //1km내 검색
+
+        KakaoDocument document = searchRes.documents().stream()
+                .filter(doc -> doc.id().equals(kakaoPlaceId))
+                .findFirst()
+                .orElseThrow(() -> new RestApiException(StoreErrorCode.STORE_NOT_EXIST));
+
+        Store newStore = Store.builder()
+                .kakaoPlaceId(document.id())
+                .name(document.placeName())
+                .address(document.addressName())
+                .roadAddress(document.roadAddressName())
+                .x(Double.valueOf(document.x()))
+                .y(Double.valueOf(document.y()))
+                .categoryName(document.categoryName())
+                .phone(document.phone())
+                .kakaoPlaceUrl(document.placeUrl()).build();
+        storeRepository.save(newStore);
+        return StoreResponseDto.from(newStore);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호 또는 링크
- #3  
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요


## 1️⃣ 가게 상세 조회를 구현했습니다.
가게 상세 조회 시에 레포지토리에 저장되도록 했습니다. 

```
{
    "code": "STORE_SEARCH_SUCCESS",
    "result": {
        "kakaoPlaceId": "8099717",
        "name": "초원복국 대연점",
        "address": "부산 남구 대연동 18-8",
        "roadAddress": "부산 남구 황령대로492번길 30",
        "phone": "051-628-3935",
        "x": 129.105899018046,
        "y": 35.1377701131047,
        "kakaoPlaceUrl": "http://place.map.kakao.com/8099717"
    }
}
```
메뉴나 다른 정보들(썸네일 등) 어떻게 받아야할지 모르겠네요..



## 2️⃣ Feignclient를 사용해서 카카오에 요청을 할 때 사용했습니다.
 feign을 사용하기 위해서 gradle에서 spring 버전을 spring 3.3.x버전으로 낮췄습니다


fegin을 이용해서 가게 검색 기능도 간단하게 구현할 수 있습니다.
```java
@FeignClient(
        name = "kakaoLocalClient",
        url = "https://dapi.kakao.com",
        configuration = KakaoFeignConfig.class
)
public interface KakaoLocalClient {

    @GetMapping("/v2/local/search/keyword.json")
    KakaoSearchResponse searchPlaceByKeywordAndPos(
            @RequestParam("query") String query,
            @RequestParam("x") Double x,
            @RequestParam("y") Double y,
            @RequestParam(value = "radius", required = false) int radius, // optional, default: 1000m
            @RequestParam("category_group_code") String categoryGroupCode
    );
}

```
카카오에 요청 보내는것들은 위를 통하면 service에서 사용할 수 있습니다!

## 3️⃣ 테스트 및 문서화
restdocs는 아직 작성하지않았고 포스트맨을 통해서 응답이 잘 오는지만 테스트했습니다. 추후에 테스트 코드는 작성 하겠습니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/3d6740fd-0f88-4c25-a5be-7ff380be6cf9)

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
