### PR TITLE
Chore/#5 Dockerfile 및 CI/CD 파이프라인 구성

### DIFF
--- a/.github/workflows/ec2-pipeline.yml
+++ b/.github/workflows/ec2-pipeline.yml
@@ -1,0 +1,74 @@
+name: ec2-pipeline.yml
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  APP_NAME : Matzipbook
+  BUILD_NAME : Matzipbook
+
+permissions:
+  contents: read
+
+jobs:
+  ec2-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up secret.yml
+        run: |
+          cd ./src/main/resources
+          touch ./application-secret.yml
+          echo "${{ secrets.APPLICATION_SECRET }}" > ./application-secret.yml
+          ls -a .
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x ./gradlew
+
+      - name: Run asciidoc mv static/html
+        run: |
+          ./gradlew asciidoctor
+          mkdir -p src/main/resources/static/docs
+          cp -r build/docs/asciidoc/* src/main/resources/static/docs/
+
+      - name: PR and PUSH Test Verification
+        run: ./gradlew test
+
+      - name: Docker push image
+        run: |
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          docker build --platform linux/arm64/v8 -t app .
+          docker tag app ${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:latest
+          docker push ${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:latest
+
+      - name: AWS deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_KEY }}
+
+          script: |
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:latest
+
+            sudo docker stop Matzipbook || true
+            sudo docker rm Matzipbook || true
+
+            sudo docker run -v /home/${{ secrets.EC2_USER }}/elk/logs:/logs -d --log-driver=syslog -p 443:8080 --name Matzipbook --network Matzipbook-network -e spring.profiles.active=release -e TZ=Asia/Seoul ${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:latest
+
+            sudo docker container prune -f
+
+            sudo docker image prune -f
+
+            sudo docker images ${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }} -q | awk 'NR>1' | xargs -r sudo docker rmi -f

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -1,0 +1,33 @@
+name: test-pipeline.yml
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+  test-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up secret.yml
+        run: |
+          cd ./src/main/resources
+          touch ./application-secret.yml
+          echo "${{ secrets.APPLICATION_SECRET }}" > ./application-secret.yml
+          ls -a .
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x ./gradlew
+
+      - name: PR and PUSH Test Verification
+        run: ./gradlew test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-ea-11-jdk-slim
+VOLUME /logs
+COPY build/libs/matzipbook-server-0.0.1-SNAPSHOT.jar Matzipbook.jar
+ENTRYPOINT ["java", "-jar", "Matzipbook.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.5'
+    id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
@@ -14,6 +14,13 @@ java {
     }
 }
 
+configurations {
+    asciidoctorExt
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
 repositories {
     mavenCentral()
 }
@@ -24,9 +31,27 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Spring TEST
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Spring REST Docs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // Spring JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // LOMBOK
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // MYSQL & H2
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {
@@ -37,4 +62,14 @@ tasks.named('test') {
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    dependsOn test
+
+    attributes 'snippets': snippetsDir
+
+    sourceDir = file('src/docs/asciidoc')
+    outputDir = file('build/docs/asciidoc')
 }

--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,0 +1,75 @@
+= Spring REST Docs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[resources-post]]
+== Authentication
+
+[[resources-post-create]]
+=== 로그인 시도
+
+==== HTTP request
+
+include::{snippets}/auth-login/http-request.adoc[]
+
+==== request-body 설명
+include::{snippets}/auth-login/request-fields.adoc[]
+
+==== HTTP response
+
+include::{snippets}/auth-login/http-response.adoc[]
+
+==== response-body 설명
+include::{snippets}/auth-login/response-fields.adoc[]
+
+
+
+=== 로그아웃
+
+==== HTTP request
+
+include::{snippets}/auth-logout/http-request.adoc[]
+
+==== request-body 설명
+include::{snippets}/auth-logout/request-fields.adoc[]
+
+==== HTTP response
+
+include::{snippets}/auth-logout/http-response.adoc[]
+
+
+
+
+=== 토큰재발급
+
+==== HTTP request
+
+include::{snippets}/auth-reissue/http-request.adoc[]
+
+==== request-body 설명
+include::{snippets}/auth-reissue/request-fields.adoc[]
+
+==== HTTP response
+
+include::{snippets}/auth-reissue/http-response.adoc[]
+
+==== response-body 설명
+include::{snippets}/auth-reissue/response-fields.adoc[]
+
+
+=== 회원탈퇴
+
+==== HTTP request
+
+include::{snippets}/auth-withdraw/http-request.adoc[]
+
+==== request-header 설명
+include::{snippets}/auth-withdraw/request-headers.adoc[]
+
+==== HTTP response
+
+include::{snippets}/auth-withdraw/http-response.adoc[]
+
+==== response-body 설명
+include::{snippets}/auth-withdraw/response-fields.adoc[]

--- a/src/main/java/com/example/matzipbookserver/global/response/CustomResponseDto.java
+++ b/src/main/java/com/example/matzipbookserver/global/response/CustomResponseDto.java
@@ -1,4 +1,4 @@
 package com.example.matzipbookserver.global.response;
 
-public record CustomResponseDto<T> (String code, T result) {
+public record CustomResponseDto<T> (String code, String message, T result) {
 }

--- a/src/main/java/com/example/matzipbookserver/global/response/SuccessResponse.java
+++ b/src/main/java/com/example/matzipbookserver/global/response/SuccessResponse.java
@@ -3,9 +3,9 @@ package com.example.matzipbookserver.global.response;
 import com.example.matzipbookserver.global.response.success.SuccessCode;
 import org.springframework.http.ResponseEntity;
 
-public class SuccessResponse<T> extends ResponseEntity {
+public class SuccessResponse<T> extends ResponseEntity<CustomResponseDto<T>> {
     public SuccessResponse(final SuccessCode successCode, final T result) {
-        super(new CustomResponseDto<>(successCode.getCode(), result),
+        super(new CustomResponseDto<>(successCode.getCode(), successCode.getMessage(), result),
                 successCode.getHttpStatus()
         );
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #5 

## 📝 작업 내용
수동 배포는 반복적이고 시간이 많이 소요되는 작업이므로 생산성을 위해 자동화 할 필요가 있다. 이를 위해 CI를 수행하는 `test-pipeline.yml`과 CD를 수행하는 `ec2-pipeline.yml`를 제작했다.

## test-pipeline.yml

```yml
on:
  push:
    branches: [ dev ]
  pull_request:
    branches: [ dev ]
```
트리거를 통해 dev 브랜치로의 Push 나 PR이 발생할 시 동작
<br>

```yml
- name: Set up JDK 17
  uses: actions/setup-java@v4
  with:
    java-version: '17'
    distribution: 'temurin'
```
actions/setup-java@v4로 JAVA 17, Temurin 배포판을 설정
<br>

```yml
- name: Set up secret.yml
  run: |
    cd ./src/main/resources
    touch ./application-secret.yml
    echo "${{ secrets.APPLICATION_SECRET }}" > ./application-secret.yml
    ls -a .
```
Git secrets에서 환경 변수를 가져와 application-secret의 파일을 만들어 ./src/main/resoucres 경로에 저장
<br>

```yml
- name: Grant execute permission for Gradle
  run: chmod +x ./gradlew
```
Graddle Wrapper 권한을 부여
<br>

```yml
- name: PR and PUSH Test Verification
  run: ./gradlew test
```
테스트를 시작
<br>

## ec2-pipeline.yml
test-pipeline의 내용과 동일한 부분은 생략

```yml
on:
  push:
    branches: [ main ]
  pull_request:
    branches: [ main ]
```
트리거를 통해 main 브랜치로의 Push 나 PR이 발생할 시 동작
<br>

```yml
env:
  APP_NAME : Matzipbook
  BUILD_NAME : Matzipbook
```
env 환경변수 설정. 민감정보는 secrets에 저장하며 자주 사용 될 정보만 env에 저장
<br>

```yml
- name: Run asciidoc mv static/html
  run: |
    ./gradlew asciidoctor
    mkdir -p src/main/resources/static/docs
    cp -r build/docs/asciidoc/* src/main/resources/static/docs/
```
- asciidoctor Gradle TASK를 실행
- buildle/docs/asciidoc/ 디렉토리에문서 생성
- static/docs로 복사
<br>


```yml
- name: Docker push image
  run: |
    docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
    docker build --platform linux/arm64/v8 -t app .
    docker tag app ${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:latest
    docker push ${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:latest
```
- GitHub Secrets 환경 변수로 Docker 로그인
- ARM 아키텍쳐도 호환가능하도록 빌드
- latest 태그를 달아서 Docker Hub로 도커 이미지 push
<br>

```yml
- name: AWS deploy
  uses: appleboy/ssh-action@master
  with:
    host: ${{ secrets.EC2_HOST }}
    username: ${{ secrets.EC2_USER }}
    key: ${{ secrets.EC2_KEY }}

    script: |
      sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:latest

      sudo docker stop Matzipbook || true
      sudo docker rm Matzipbook || true

      sudo docker run -v /home/${{ secrets.EC2_USER }}/elk/logs:/logs -d --log-driver=syslog -p 443:8080 --name Matzipbook --network Matzipbook-network -e spring.profiles.active=release -e TZ=Asia/Seoul ${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:latest

      sudo docker container prune -f

      sudo docker image prune -f

      sudo docker images ${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }} -q | awk 'NR>1' | xargs -r sudo docker rmi -f
```
- GitHub Secrets 환경 변수로 EC2 SSH 접속
- Docker Hub에서 도커 이미지 pull
- 기존에 실행 중인 컨테이너가 있다면 중지하고 제거
- `newtork = Matzipbook-newtork`, `profile = release`로 새 이미지로 컨테이너 실행
- 사용하지 않는 이미지 정리
<br>

## applicaion.yml 컨벤션
배포 자동화와 원만한 협업을 위해 Applicaion.yml 컨벤션을 다음과 같이 한다

## applicaion.yml
```yml
spring:
  profiles:
    active: dev
```
상황에 따라 적용할 프로파일을 선택

## applicaion-secret.yml
```yml
kakao-api-key: ~
jwt-secret: ~
```
코드 복사하여 `GITHUB > Settings > Actions secrets and variables > Actions` 에서 적용

## applicaion-release.yml
```yml
datasource:
  url: jdbc:mysql://localhost:3306.....
  username: root
  password: qwer1234
```
EC2 배포 시 필요한 정보 관리