### PR TITLE
Feat/#21 서버 자체 Access/Refresh 토큰 구현

### DIFF
--- a/src/main/java/com/example/matzipbookserver/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/matzipbookserver/global/jwt/JwtTokenProvider.java
@@ -3,8 +3,10 @@ package com.example.matzipbookserver.global.jwt;
 import com.example.matzipbookserver.global.exception.RestApiException;
 import com.example.matzipbookserver.global.response.error.AuthErrorCode;
 import com.example.matzipbookserver.global.response.error.MemberErrorCode;
+import com.example.matzipbookserver.member.domain.LoginMember;
 import com.example.matzipbookserver.member.domain.Member;
 import com.example.matzipbookserver.member.repository.MemberRepository;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -22,6 +24,12 @@ public class JwtTokenProvider {
     @Value("${jwt.secret}")
     private String secret;
 
+    @Value("${jwt.access-token-valid-time}")
+    private long accessTokenValidTime;
+
+    @Value("${jwt.refresh-token-valid-time}")
+    private Long refreshTokenValidTime;
+
     private SecretKey secretKey;
 
     public JwtTokenProvider(MemberRepository memberRepository) {
@@ -34,11 +42,21 @@ public class JwtTokenProvider {
         this.secretKey = Keys.hmacShaKeyFor(decodedKey);
     }
 
-    public String createAccessToken(String provider, String providerId) {
+    public String generateAccessToken(LoginMember loginMember) {
         return Jwts.builder()
-                .setSubject(provider + ":" + providerId)
+                .setSubject(loginMember.provider()+ ":" + loginMember.providerId())
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + 3600 * 1000))
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenValidTime))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String generateRefreshToken(LoginMember loginMember, long tokenId) {
+        return Jwts.builder()
+                .setSubject(loginMember.provider() + ":" + loginMember.providerId())
+                .claim("tokenId",tokenId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenValidTime))
                 .signWith(secretKey)
                 .compact();
     }
@@ -79,6 +97,40 @@ public class JwtTokenProvider {
                     .build()
                     .parseClaimsJws(token);
             return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Long getTokenIdFromToken(String token) {
+        try {
+            Claims cliams = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return cliams.get("tokenId",Long.class);
+        } catch (Exception e) {
+            throw new RestApiException(AuthErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    public LoginMember getLoginMemberFromToken(String token) {
+        String subject = getSubject(token);
+        String[] parts = subject.split(":");
+        if (parts.length != 2) {
+            throw new RestApiException(AuthErrorCode.INVALID_TOKEN);
+        }
+        return new LoginMember(parts[0], parts[1]);
+    }
+
+    public boolean isNotExpiredToken(String token) {
+        try {
+            Date expiration = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token).getBody().getExpiration();
+            return expiration.after(new Date());
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/com/example/matzipbookserver/global/response/error/AuthErrorCode.java
+++ b/src/main/java/com/example/matzipbookserver/global/response/error/AuthErrorCode.java
@@ -3,13 +3,20 @@ package com.example.matzipbookserver.global.response.error;
 import org.springframework.http.HttpStatus;
 
 public enum AuthErrorCode implements ErrorCode {
-    KAKAO_TOKEN_REQUEST_FAIL("AUTH-001", HttpStatus.BAD_REQUEST, "카카오 토큰 요청에 실패했습니다." ),
-    KAKAO_USER_INFO_FAIL("AUTH-002",HttpStatus.BAD_REQUEST, "카카오 사용자 정보 요청에 실패했습니다."),
-    KAKAO_EMAIL_NOT_PROVIDED("AUTH-003", HttpStatus.BAD_REQUEST, "이메일 정보가 제공되지 않았습니다."),
-    APPLE_TOKEN_REQUEST_FAIL("AUTH-004", HttpStatus.BAD_REQUEST, "애플 토큰 요청에 실패했습니다."),
-    APPLE_EMAIL_NOT_PROVIDED("AUTH-005", HttpStatus.BAD_REQUEST, "애플 이메일 정보가 제공되지 않았습니다."),
-    APPLE_ID_TOKEN_PARSE_FAILED("AUTH-006", HttpStatus.UNAUTHORIZED, "Apple ID Token 파싱에 실패했습니다."),
-    INVALID_TOKEN("AUTH-007", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+    KAKAO_TOKEN_REQUEST_FAIL("AUTH_KAKAO_TOKEN_REQUEST_FAIL_001", HttpStatus.BAD_REQUEST, "카카오 토큰 요청에 실패했습니다."),
+    KAKAO_USER_INFO_FAIL("AUTH_KAKAO_USER_INFO_FAIL_002", HttpStatus.BAD_REQUEST, "카카오 사용자 정보 요청에 실패했습니다."),
+    KAKAO_EMAIL_NOT_PROVIDED("AUTH_KAKAO_EMAIL_NOT_PROVIDED_003", HttpStatus.BAD_REQUEST, "이메일 정보가 제공되지 않았습니다."),
+
+    APPLE_TOKEN_REQUEST_FAIL("AUTH_APPLE_TOKEN_REQUEST_FAIL_004", HttpStatus.BAD_REQUEST, "애플 토큰 요청에 실패했습니다."),
+    APPLE_EMAIL_NOT_PROVIDED("AUTH_APPLE_EMAIL_NOT_PROVIDED_005", HttpStatus.BAD_REQUEST, "애플 이메일 정보가 제공되지 않았습니다."),
+    APPLE_ID_TOKEN_PARSE_FAILED("AUTH_APPLE_ID_TOKEN_PARSE_FAILED_006", HttpStatus.UNAUTHORIZED, "Apple ID Token 파싱에 실패했습니다."),
+
+    INVALID_TOKEN("AUTH_INVALID_TOKEN_007", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN("AUTH_EXPIRED_REFRESH_TOKEN_008", HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다."),
+    NOT_ACCESS_TOKEN_FOR_REISSUE("AUTH_NOT_ACCESS_TOKEN_FOR_REISSUE_009", HttpStatus.BAD_REQUEST, "재발급 대상이 아닌 액세스 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN_DB("AUTH_EXPIRED_REFRESH_TOKEN_DB_010", HttpStatus.UNAUTHORIZED, "서버에서 만료 처리된 리프레시 토큰입니다."),
+    NULL_REFRESH_TOKEN("AUTH_NULL_REFRESH_TOKEN_011", HttpStatus.UNAUTHORIZED, "DB에 존재하지 않는 리프레시 토큰입니다.");
+
 
     private final String developCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/matzipbookserver/global/response/error/MemberErrorCode.java
+++ b/src/main/java/com/example/matzipbookserver/global/response/error/MemberErrorCode.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum MemberErrorCode implements ErrorCode {
 
-    ALREADY_REGISTERED("MEMBER-001",HttpStatus.BAD_REQUEST, "이미 가입된 사용자입니다."),
-    MEMBER_NOT_FOUND("MEMBER-002", HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다.");
+    ALREADY_REGISTERED("MEMBER_ALREADY_REGISTERED_001",HttpStatus.BAD_REQUEST, "이미 가입된 사용자입니다."),
+    MEMBER_NOT_FOUND("MEMBER_NOT_FOUND_002", HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다.");
 
     private final String developCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/matzipbookserver/global/response/success/MemberSuccessCode.java
+++ b/src/main/java/com/example/matzipbookserver/global/response/success/MemberSuccessCode.java
@@ -3,11 +3,12 @@ package com.example.matzipbookserver.global.response.success;
 import org.springframework.http.HttpStatus;
 
 public enum MemberSuccessCode implements SuccessCode {
-    LOGIN_SUCCESS(HttpStatus.OK,"MEMBER-001","로그인 성공"),
-    SIGNUP_REQUIRED(HttpStatus.OK, "MEMBER-002", "회원가입 필요"),
-    SIGNUP_SUCCESS(HttpStatus.OK, "MEMBER-003","회원가입 성공"),
-    FCM_TOKEN_SAVED(HttpStatus.OK, "MEMBER-004", "FCM 토큰 저장 완료"),
-    MEMBER_INFO_SUCCESS(HttpStatus.OK,"MEMBER-005", "회원 정보 조회 성공");
+    LOGIN_SUCCESS(HttpStatus.OK,"MEMBER_LOGIN_SUCCESS_001","로그인 성공"),
+    SIGNUP_REQUIRED(HttpStatus.OK, "MEMBER_SIGNUP_REQUIRED_002", "회원가입 필요"),
+    SIGNUP_SUCCESS(HttpStatus.OK, "MEMBER_SIGNUP_SUCCESS_003","회원가입 성공"),
+    FCM_TOKEN_SAVED(HttpStatus.OK, "MEMBER_FCM_SAVED_004", "FCM 토큰 저장 완료"),
+    MEMBER_INFO_SUCCESS(HttpStatus.OK,"MEMBER_INFO_SUCCESS_005", "회원 정보 조회 성공"),
+    REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "REISSUE_TOKEN_SUCCESS_006", "토큰 재발급 완료");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/matzipbookserver/member/controller/AuthController.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/AuthController.java
@@ -64,6 +64,16 @@ public class AuthController {
         }
     }
 
+
+    @PostMapping("/reissue")
+    public SuccessResponse<AuthToken> reissue(@RequestBody AuthToken authToken) {
+        return SuccessResponse.of(
+                MemberSuccessCode.REISSUE_TOKEN_SUCCESS,
+                authService.reissue(authToken)
+        );
+    }
+
+
     @PostMapping("/signup")
     public SuccessResponse<SignupResponse> signup(@RequestBody SignupRequest request) {
         SignupResponse response = memberService.signup(request);

--- a/src/main/java/com/example/matzipbookserver/member/controller/dto/response/AppleLoginResponse.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/dto/response/AppleLoginResponse.java
@@ -1,5 +1,5 @@
 package com.example.matzipbookserver.member.controller.dto.response;
 
-public record AppleLoginResponse (String jwtToken, UserInfo user) implements LoginResponse {
+public record AppleLoginResponse (AuthToken authToken, UserInfo user) implements LoginResponse {
     public record UserInfo(Long id, String email) {}
 }

--- a/src/main/java/com/example/matzipbookserver/member/controller/dto/response/AuthToken.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/dto/response/AuthToken.java
@@ -1,0 +1,6 @@
+package com.example.matzipbookserver.member.controller.dto.response;
+
+public record AuthToken(
+        String accessToken,
+        String refreshToken
+) {}

--- a/src/main/java/com/example/matzipbookserver/member/controller/dto/response/KakaoLoginResponse.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/dto/response/KakaoLoginResponse.java
@@ -2,7 +2,7 @@ package com.example.matzipbookserver.member.controller.dto.response;
 
 
 public record KakaoLoginResponse (
-    String jwtToken,
+    AuthToken authToken,
     UserInfo user
 ) implements LoginResponse{
     public record UserInfo(

--- a/src/main/java/com/example/matzipbookserver/member/controller/dto/response/SignupResponse.java
+++ b/src/main/java/com/example/matzipbookserver/member/controller/dto/response/SignupResponse.java
@@ -6,6 +6,5 @@ import lombok.Builder;
 public record SignupResponse (
         Long id,
         String email,
-        String nickname,
-        String jwtToken
+        String nickname
 ) {}

--- a/src/main/java/com/example/matzipbookserver/member/domain/LoginMember.java
+++ b/src/main/java/com/example/matzipbookserver/member/domain/LoginMember.java
@@ -1,0 +1,7 @@
+package com.example.matzipbookserver.member.domain;
+
+
+public record LoginMember(
+        String provider,
+        String providerId
+) {}

--- a/src/main/java/com/example/matzipbookserver/member/domain/RefreshToken.java
+++ b/src/main/java/com/example/matzipbookserver/member/domain/RefreshToken.java
@@ -1,0 +1,54 @@
+package com.example.matzipbookserver.member.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class RefreshToken {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tokenId")
+    private Long id;
+
+    @Column
+    private String refreshToken;
+
+    @Column
+    private boolean isExpired = false;
+
+    @Column
+    private LocalDateTime recentLogin = LocalDateTime.now();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId")
+    private Member member;
+
+    protected RefreshToken() {}
+
+    public RefreshToken(Member member, String refreshToken) {
+        this.member = member;
+        this.refreshToken = refreshToken;
+    }
+
+    public void putRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void expire() {
+        isExpired = true;
+    }
+
+    public boolean isExpired() {
+        return isExpired;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void changeRecentLogin() {
+        recentLogin = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/example/matzipbookserver/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/matzipbookserver/member/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.example.matzipbookserver.member.repository;
+
+import com.example.matzipbookserver.member.domain.Member;
+import com.example.matzipbookserver.member.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByMember(Member member);
+
+    void deleteAllByMember(Member member);
+}

--- a/src/main/java/com/example/matzipbookserver/member/service/MemberService.java
+++ b/src/main/java/com/example/matzipbookserver/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.example.matzipbookserver.global.exception.RestApiException;
 import com.example.matzipbookserver.global.jwt.JwtTokenProvider;
 import com.example.matzipbookserver.member.controller.dto.request.SignupRequest;
 import com.example.matzipbookserver.member.controller.dto.response.SignupResponse;
+import com.example.matzipbookserver.member.domain.LoginMember;
 import com.example.matzipbookserver.member.domain.Member;
 import com.example.matzipbookserver.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,15 +33,14 @@ public class MemberService {
                 request.profileImagePath(),
                 request.university()
         );
-        Member saved = memberRepository.save(member);
 
-        String jwt = jwtTokenProvider.createAccessToken(saved.getProvider(), saved.getProviderId());
+        Member saved = memberRepository.save(member);
 
         return new SignupResponse(
                 saved.getId(),
                 saved.getEmail(),
-                saved.getNickname(),
-                jwt
+                saved.getNickname()
         );
     }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Resolved #21 

## 📝 작업 내용
Access/Refresh Token 발급 및 재발급 기능을 구현했습니다!

**1️⃣ JWT 기반 토큰 설계**

- LoginMember 객체 기반으로 JWT subject 설정
- RefreshToken 엔티티 생성 및 DB 설정

**2️⃣ 토큰 발급 및 재발급 로직 구현**

- 로그인 시 Access/Refresh 토큰 동시에 발급
- RefreshToken의 tokenId → 재발급 시에 검증
- `/api/auth/reissue` API로 AccessToken 재발급

**3️⃣ 테스트**

- Postman으로 토큰 만료/재발급 테스트 완료


## 💬 리뷰 요구사항 
🙇‍♀️ 구현은 최선을 다해 진행했지만, 코드 흐름에 대한 이해가 부족한 부분이 있습니다.
어색한 로직이 있다면 편하게 코멘트 부탁드립니다 :)
